### PR TITLE
Minor fix: remove rild.libpath from the system.prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -65,9 +65,6 @@ debug.composition.type=gpu
 # Display
 persist.hwc.mdpcomp.enable=true
 
-# Telephony
-rild.libpath=/system/lib/libril-qc-qmi-1.so
-
 # Preferred network type - LTE, WCDMA, GSM
 ro.telephony.default_network=9
 ro.telephony.get_imsi_from_sim=true


### PR DESCRIPTION
Pay attention to these lines:
https://github.com/yatto/android_device_duma/blob/lineage-15/device.mk#L56-L57